### PR TITLE
Add Metavault.Trade fees adapter

### DIFF
--- a/fees/metavault.trade.ts
+++ b/fees/metavault.trade.ts
@@ -1,0 +1,56 @@
+import { Chain } from "@defillama/sdk/build/general";
+import { gql, request } from "graphql-request";
+import type { ChainEndpoints } from "../adapters/types";
+import { Adapter } from "../adapters/types";
+import { POLYGON } from "../helpers/chains";
+import { getTimestampAtStartOfDayUTC } from "../utils/date";
+
+const endpoints = {
+  [POLYGON]: "https://api.thegraph.com/subgraphs/name/sdcrypt0/metavault-mvx-subgraph",
+};
+
+const graphs = (graphUrls: ChainEndpoints) => {
+  return (chain: Chain) => {
+    return async (timestamp: number) => {
+      const todaysTimestamp = getTimestampAtStartOfDayUTC(timestamp);
+      const searchTimestamp = todaysTimestamp + ":daily";
+
+      const graphQuery = gql`{
+        feeStat(id: "${searchTimestamp}") {
+          mint
+          burn
+          marginAndLiquidation
+          swap
+        }
+      }`;
+
+      const graphRes = await request(graphUrls[chain], graphQuery);
+
+      const dailyFee =
+        parseInt(graphRes.feeStat.mint) +
+        parseInt(graphRes.feeStat.burn) +
+        parseInt(graphRes.feeStat.marginAndLiquidation) +
+        parseInt(graphRes.feeStat.swap);
+      const finalDailyFee = dailyFee / 1e30;
+
+      return {
+        timestamp,
+        totalFees: "0",
+        dailyFees: finalDailyFee.toString(),
+        totalRevenue: "0",
+        dailyRevenue: (finalDailyFee * 0.3).toString(),
+      };
+    };
+  };
+};
+
+const adapter: Adapter = {
+  adapter: {
+    [POLYGON]: {
+      fetch: graphs(endpoints)(POLYGON),
+      start: async () => 1655784000,
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Metavault.Trade's daily fee and revenue calculation is quite simple. All mint, burn, marginAndLiquidation and  swap fees are collected and the daily fee amount is determined. Daily revenue is calculated as 30% of the total fee. 


Here is the test results: 

🦙 Running METAVAULT.TRADE adapter 🦙
_______________________________________
Fees for 25/10/2022
_______________________________________

POLYGON 👇
Backfill start time: 21/6/2022
Timestamp: 1666655999
Total fees: 0
Daily fees: 3253.420785120958
Total revenue: 0
Daily revenue: 976.0262355362873
