### PR TITLE
add MUX fees adapter

### DIFF
--- a/fees/index.ts
+++ b/fees/index.ts
@@ -30,6 +30,7 @@ import tarot from "./tarot";
 import woofi from "./woofi";
 import fraxSwap from "./frax-swap";
 import angle from "./angle";
+import mux from "./mux";
 
 export default {
     sushiswap,
@@ -63,5 +64,6 @@ export default {
     tarot,
     woofi,
     "frax-swap": fraxSwap,
-    angle
+    angle,
+    mux
 };

--- a/fees/index.ts
+++ b/fees/index.ts
@@ -30,7 +30,6 @@ import tarot from "./tarot";
 import woofi from "./woofi";
 import fraxSwap from "./frax-swap";
 import angle from "./angle";
-import mux from "./mux";
 
 export default {
     sushiswap,
@@ -64,6 +63,5 @@ export default {
     tarot,
     woofi,
     "frax-swap": fraxSwap,
-    angle,
-    mux
+    angle
 };

--- a/fees/mux.ts
+++ b/fees/mux.ts
@@ -30,6 +30,10 @@ const formatMetaBaseData = (cols: Array<any>, rows: Array<Array<any>>) => {
   })
 }
 
+const formatDate = (date: number) => {
+  return date < 10 ? `0${date}` : `${date}`
+}
+
 const computeRevenue = (fee: number, por: number) => {
   // fee × 70% × POR: Allocate for veMUX holders (in ETH)
   // fee × 30%: Purchase MUXLP and add as protocol-owned liquidity
@@ -39,7 +43,7 @@ const computeRevenue = (fee: number, por: number) => {
 const getFees = (chainId: CHAIN_ID) => {
   return async (timestamp: number) => {
     const date = new Date(timestamp * 1000)
-    const dateTime = `${date.getUTCFullYear()}-${date.getUTCMonth()+1}-${date.getUTCDate()+1}`
+    const dateTime = `${date.getUTCFullYear()}-${formatDate(date.getUTCMonth()+1)}-${formatDate(date.getUTCDate())}`
     const parameter = `[{"type":"date/single","value":"${dateTime}","target":["variable",["template-tag","timestamp"]],"id":"eff4a885"}]`
     const feePathUrl = `${feesDataEndpoint}?parameters=${encodeURIComponent(parameter)}&dashboard_id=2`
     const porPathUrl = `${porDataEndpoint}?parameters=${encodeURIComponent(parameter)}&dashboard_id=2`

--- a/fees/mux.ts
+++ b/fees/mux.ts
@@ -1,0 +1,90 @@
+import { Adapter } from "../adapters/types";
+import {ARBITRUM, AVAX, BSC, FANTOM} from "../helpers/chains";
+import fetchURL from "../utils/fetchURL";
+
+enum CHAIN_ID {
+  ARB = 42161,
+  BSC = 56,
+  FTM = 250,
+  AVALANCHE = 43114,
+}
+
+interface FeesMetaBaseData {
+  fee: number
+  chain_id: number
+}
+
+const feesDataEndpoint = 'https://app.mux.network/metabase/api/public/dashboard/a8bbcebe-3ad6-40c0-8afa-0140366024fe/dashcard/150/card/113'
+const porDataEndpoint = 'https://app.mux.network/metabase/api/public/dashboard/a8bbcebe-3ad6-40c0-8afa-0140366024fe/dashcard/151/card/115'
+
+const formatMetaBaseData = (cols: Array<any>, rows: Array<Array<any>>) => {
+  const keys = cols.map((col) => {
+    return col.display_name
+  })
+  return rows.map((row) => {
+    const obj: any = {}
+    row.map((item, index) => {
+      obj[keys[index]] = item
+    })
+    return obj
+  })
+}
+
+const computeRevenue = (fee: number, por: number) => {
+  // fee × 50% × POR: Allocate for veMUX holders (in ETH)
+  // fee × 50%: Purchase MUXLP and add as protocol-owned liquidity
+  return (fee * 0.5 * por) + (fee * 0.5)
+}
+
+const getFees = (chainId: CHAIN_ID) => {
+  return async (timestamp: number) => {
+    const date = new Date(timestamp * 1000)
+    const dateTime = `${date.getUTCFullYear()}-${date.getUTCMonth()+1}-${date.getUTCDate()+1}`
+    const parameter = `[{"type":"date/single","value":"${dateTime}","target":["variable",["template-tag","timestamp"]],"id":"eff4a885"}]`
+    const feePathUrl = `${feesDataEndpoint}?parameters=${encodeURIComponent(parameter)}&dashboard_id=2`
+    const porPathUrl = `${porDataEndpoint}?parameters=${encodeURIComponent(parameter)}&dashboard_id=2`
+    const feeData = (await fetchURL(feePathUrl))?.data.data
+    const por = (await fetchURL(porPathUrl))?.data.data.rows[0][0]
+
+    const result = formatMetaBaseData(feeData.cols, feeData.rows) as FeesMetaBaseData[]
+    let dailyFees = 0
+
+    for (const v of result) {
+      if (v.chain_id === chainId) {
+        dailyFees = v.fee
+        break
+      }
+    }
+
+    return {
+      timestamp,
+      totalFees: "0",
+      dailyFees: dailyFees.toString(),
+      totalRevenue: "0",
+      dailyRevenue: computeRevenue(dailyFees, por).toString(),
+    };
+  }
+}
+
+const adapter: Adapter = {
+  adapter: {
+    [ARBITRUM]: {
+      fetch: getFees(CHAIN_ID.ARB),
+      start: async ()  => 1659312000, // 2022-08-01
+    },
+    [BSC]: {
+      fetch: getFees(CHAIN_ID.BSC),
+      start: async ()  => 1659312000, // 2022-08-01
+    },
+    [AVAX]: {
+      fetch: getFees(CHAIN_ID.AVALANCHE),
+      start: async ()  => 1659312000, // 2022-08-01
+    },
+    [FANTOM]: {
+      fetch: getFees(CHAIN_ID.FTM),
+      start: async ()  => 1659312000, // 2022-08-01
+    },
+  }
+}
+
+export default adapter;

--- a/fees/mux.ts
+++ b/fees/mux.ts
@@ -31,9 +31,9 @@ const formatMetaBaseData = (cols: Array<any>, rows: Array<Array<any>>) => {
 }
 
 const computeRevenue = (fee: number, por: number) => {
-  // fee × 50% × POR: Allocate for veMUX holders (in ETH)
-  // fee × 50%: Purchase MUXLP and add as protocol-owned liquidity
-  return (fee * 0.5 * por) + (fee * 0.5)
+  // fee × 70% × POR: Allocate for veMUX holders (in ETH)
+  // fee × 30%: Purchase MUXLP and add as protocol-owned liquidity
+  return (fee * 0.7 * por) + (fee * 0.3)
 }
 
 const getFees = (chainId: CHAIN_ID) => {


### PR DESCRIPTION
revenue:
fee × 70% × POR: Allocate for veMUX holders (in ETH)
fee × 30%: Purchase MUXLP and add as protocol-owned liquidity
POR is the rate of [Protocol Owned Liquidity](https://github.com/protocol/liquidity#protocol-owned-liquidity)

Here is the test results:
🦙 Running MUX adapter 🦙
_______________________________________
Fees for 28/10/2022
_______________________________________

ARBITRUM 👇
Backfill start time: 1/8/2022
Timestamp: 1666915199
Total fees: 0
Daily fees: 35089.84287823406
Total revenue: 0
Daily revenue: 28102.765039470443


BSC 👇
Backfill start time: 1/8/2022
Timestamp: 1666915199
Total fees: 0
Daily fees: 175.16929680025882
Total revenue: 0
Daily revenue: 140.28964470400837


AVAX 👇
Backfill start time: 1/8/2022
Timestamp: 1666915199
Total fees: 0
Daily fees: 1214.0303679698818
Total revenue: 0
Daily revenue: 972.2930450339036


FANTOM 👇
Backfill start time: 1/8/2022
Timestamp: 1666915199
Total fees: 0
Daily fees: 209.50287902086188
Total revenue: 0
Daily revenue: 167.786735456371

