### PR TITLE
Add Metavault.Trade Dexs Adapter

### DIFF
--- a/dexs/metavault.trade/index.ts
+++ b/dexs/metavault.trade/index.ts
@@ -1,0 +1,73 @@
+import request, { gql } from "graphql-request";
+import { Fetch, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+
+const endpoints: { [key: string]: string } = {
+  [CHAIN.POLYGON]: "https://api.thegraph.com/subgraphs/name/sdcrypt0/metavault-mvx-subgraph",
+}
+
+const historicalData = gql`
+  query get_volume($period: String!, $id: String!) {
+    volumeStats(where: {period: $period, id: $id}) {
+        swap
+      }
+  }
+`
+
+interface IGraphResponse {
+  volumeStats: Array<{
+    burn: string,
+    liquidation: string,
+    margin: string,
+    mint: string,
+    swap: string,
+  }>
+}
+
+const getFetch = (chain: string): Fetch => async (timestamp: number) => {
+  const dayTimestamp = getUniqStartOfTodayTimestamp(new Date((timestamp * 1000)))
+  const dailyData: IGraphResponse = await request(endpoints[chain], historicalData, {
+    id: String(dayTimestamp) + ':daily',
+    period: 'daily',
+  })
+  const totalData: IGraphResponse = await request(endpoints[chain], historicalData, {
+    id: 'total',
+    period: 'total',
+  })
+
+  return {
+    timestamp: dayTimestamp,
+    dailyVolume:
+      dailyData.volumeStats.length == 1
+        ? String(Number(Object.values(dailyData.volumeStats[0]).reduce((sum, element) => String(Number(sum) + Number(element)))) * 10 ** -30)
+        : undefined,
+    totalVolume:
+      totalData.volumeStats.length == 1
+        ? String(Number(Object.values(totalData.volumeStats[0]).reduce((sum, element) => String(Number(sum) + Number(element)))) * 10 ** -30)
+        : undefined,
+
+  }
+}
+
+const getStartTimestamp = async (chain: string) => {
+  const startTimestamps: { [chain: string]: number } = {
+    [CHAIN.POLYGON]: 1654041600,
+  }
+  return startTimestamps[chain]
+}
+
+const adapter: SimpleAdapter = {
+  adapter: Object.keys(endpoints).reduce((acc, chain) => {
+    return {
+      ...acc,
+      [chain]: {
+        fetch: getFetch(chain),
+        start: async () => getStartTimestamp(chain),
+        runAtCurrTime: true
+      }
+    }
+  }, {})
+}
+
+export default adapter;

--- a/fees/metavault.trade/index.ts
+++ b/fees/metavault.trade/index.ts
@@ -48,7 +48,7 @@ const adapter: Adapter = {
   adapter: {
     [POLYGON]: {
       fetch: graphs(endpoints)(POLYGON),
-      start: async () => 1655784000,
+      start: async () => 1654041600,
       meta: {
         methodology: 'All mint, burn, marginAndLiquidation and swap fees are collected and the daily fee amount is determined. Daily revenue is calculated as 30% of the total fee.'
       }


### PR DESCRIPTION
There are two changes in this request. 

First one is for fees adapter. Just updated start timestamp. 

Second is dexs adapter for Metavault.Trade. 

Here is the dexs test result for metavault.trade: 

🦙 Running METAVAULT.TRADE adapter 🦙
_______________________________________
Dexs for 28/10/2022
_______________________________________

POLYGON 👇
Backfill start time: 1/6/2022
Timestamp: 1666828800
Daily volume: 2817879.536517962
Total volume: 103306188.25407264
