### PR TITLE
3xcalibur dex volume

### DIFF
--- a/dexs/3xcalibur/index.ts
+++ b/dexs/3xcalibur/index.ts
@@ -1,0 +1,36 @@
+import { SimpleAdapter } from "../../adapters/types";
+import { getStartTimestamp } from "../../helpers/getStartTimestamp";
+import { DEFAULT_DAILY_VOLUME_FIELD, DEFAULT_TOTAL_VOLUME_FIELD, getChainVolume } from "../../helpers/getUniSubgraphVolume";
+import { CHAIN } from "../../helpers/chains";
+
+const endpoints = {
+  [CHAIN.ARBITRUM]: "https://api.thegraph.com/subgraphs/name/0xleez/xcali-arbitrum",
+};
+
+const graphs = getChainVolume({
+  graphUrls: endpoints,
+  totalVolume: {
+    factory: "swapFactories",
+    field: DEFAULT_TOTAL_VOLUME_FIELD,
+  },
+  dailyVolume: {
+    factory: "uniswapDayData",
+    field: DEFAULT_DAILY_VOLUME_FIELD,
+  },
+});
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.ARBITRUM]: {
+      fetch: graphs(CHAIN.ARBITRUM),
+      start: getStartTimestamp({
+        endpoints: endpoints,
+        chain: CHAIN.ARBITRUM,
+        volumeField: DEFAULT_DAILY_VOLUME_FIELD,
+        dailyDataField: "uniswapDayDatas",
+      }),
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION

```
$ yarn test dexs 3xcalibur 

🦙 Running 3XCALIBUR adapter 🦙
_______________________________________
Dexs for 14/11/2022
_______________________________________

ARBITRUM 👇
Backfill start time: 6/11/2022
Timestamp: 1668470398
Block: 38150548
Total volume: 18512243.381527524
Daily volume: 808403.6401395025544086973515575722




✨  Done in 13.69s.
```